### PR TITLE
Corrigido erro ao cadastrar nova ocorrência

### DIFF
--- a/app/controllers/incidents_controller.rb
+++ b/app/controllers/incidents_controller.rb
@@ -100,7 +100,9 @@ class IncidentsController < ApplicationController
   end
 
   def send_email_to(coordinator)
-    InsidentMailer.send_mailer(coordinator).deliver_now unless Rails.env.test?
+    if coordinator.present?
+      InsidentMailer.send_mailer(coordinator).deliver_now
+    end
   end
 
   def set_incident


### PR DESCRIPTION
Todas as ocorrências, caso exista um coordenador(a) associado ao curso, o mesmo receberá um email relatando que há uma nova ocorrência. Caso não exista um coordenador(a) associado, o envio do email é descartado.

Closed #108 