### PR TITLE
Desativar usuários que possuam ocorrências cadastradas

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,7 +3,12 @@
 class SessionsController < Devise::SessionsController
   def create
     self.resource = warden.authenticate!(auth_options)
-    set_flash_message(:notice, :signed_in) if is_flashing_format?
-    redirect_to root_path if sign_in(resource_name, resource)
+    _sign_in = sign_in(resource_name, resource)
+    if resource.status && _sign_in
+      set_flash_message(:notice, :signed_in) if is_flashing_format?
+      redirect_to root_path
+    else 
+      sign_out_and_redirect(resource_name) 
+    end
   end
 end

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -98,6 +98,12 @@
             <%= f.check_box :admin %>
           </p>
         </div>
+        <div class="field">
+          <p class="control">
+            <%= f.label :status, 'Ativo?', class: 'label' %>
+            <%= f.check_box :status %>
+          </p>
+        </div>
       </div>
     </div>
   </fieldset>

--- a/db/migrate/20200314034731_add_status_to_user.rb
+++ b/db/migrate/20200314034731_add_status_to_user.rb
@@ -1,0 +1,5 @@
+class AddStatusToUser < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :status, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_22_151132) do
+ActiveRecord::Schema.define(version: 2020_03_14_034731) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,8 +39,8 @@ ActiveRecord::Schema.define(version: 2020_02_22_151132) do
     t.integer "is_resolved"
     t.integer "type_student"
     t.integer "sanction"
-    t.bigint "type_incident_id"
     t.integer "school_group_id"
+    t.bigint "type_incident_id"
     t.index ["course_id"], name: "index_incidents_on_course_id"
     t.index ["date_incident"], name: "index_incidents_on_date_incident"
     t.index ["institution"], name: "index_incidents_on_institution"
@@ -226,6 +226,24 @@ ActiveRecord::Schema.define(version: 2020_02_22_151132) do
     t.index ["school_group_id"], name: "index_students_on_school_group_id"
   end
 
+  create_table "tickets", id: :serial, force: :cascade do |t|
+    t.string "from"
+    t.string "to"
+    t.string "subject"
+    t.integer "priority", default: 0
+    t.text "description"
+    t.integer "status", default: 0
+    t.integer "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "local"
+    t.integer "answer"
+    t.index ["from"], name: "index_tickets_on_from"
+    t.index ["status"], name: "index_tickets_on_status"
+    t.index ["to"], name: "index_tickets_on_to"
+    t.index ["user_id"], name: "index_tickets_on_user_id"
+  end
+
   create_table "type_incidents", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
@@ -252,6 +270,7 @@ ActiveRecord::Schema.define(version: 2020_02_22_151132) do
     t.string "avatar"
     t.bigint "course_id"
     t.boolean "admin", default: false
+    t.boolean "status", default: true
     t.index ["course_id"], name: "index_users_on_course_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
@@ -271,6 +290,7 @@ ActiveRecord::Schema.define(version: 2020_02_22_151132) do
   add_foreign_key "permissions", "users"
   add_foreign_key "students", "courses"
   add_foreign_key "students", "school_groups"
+  add_foreign_key "tickets", "users"
   add_foreign_key "users", "courses"
   add_foreign_key "users", "sectors"
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -36,6 +36,7 @@ FactoryBot.define do
     username { Faker::Internet.user_name }
     siape { Faker::Number.number(7) }
     sector
+    status { true }
     admin { false }
   end
 end

--- a/spec/features/user/autentication_spec.rb
+++ b/spec/features/user/autentication_spec.rb
@@ -15,6 +15,11 @@ context 'User' do
       sign_in user, password: 'wrongpassword'
       expect(page).to have_content('Inválido Username ou senha.')
     end
+
+    scenario 'with status false' do
+      sign_in FactoryBot.create(:user, status: false)
+      expect(page).to have_content('Para continuar, faça login ou registre-se.')
+    end
   end
 
   feature 'sign out' do


### PR DESCRIPTION
# Usuário

### Alterações de funcionalidades

- Adicionado atributo status para o formulário de cadastro do usuário; Os usuários que estiverem com status desativado não poderão realizar login no sistema.

![Captura de Tela 2020-03-14 às 00 22 59](https://user-images.githubusercontent.com/1373275/76674850-132f9880-658a-11ea-8a52-9114e708ee42.png)

### Alterações Técnicas
  - Modificado controler Session para deslogar os usuários que estiverem status como false;
  - Adicionado atributo status para usuários;
  - Adicionado testes para contemplar nova funcionalidade.