### PR TITLE
fix: add alt text to IFMS logo

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -5,7 +5,7 @@
 
 	<section class="container">
 		<div class="devise-logo">
-      <%= image_tag '/ifms-cor.png', width: 120 %>
+      <%= image_tag '/ifms-cor.png', width: 120, alt: 'Instituto Federal de Mato Grosso do Sul' %>
     </div>
 
 		<div class="devise-content">

--- a/app/views/insident_mailer/send_mailer.html.erb
+++ b/app/views/insident_mailer/send_mailer.html.erb
@@ -103,7 +103,7 @@
                   <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
                     <tr>
                       <td style="font-family: sans-serif; font-size: 14px; vertical-align: top; text-align: center">
-                        <img src="http://selecao.ifms.edu.br/assets/images/ifms-cor.png" alt="">
+                        <img src="http://selecao.ifms.edu.br/assets/images/ifms-cor.png" alt="Instituto Federal de Mato Grosso do Sul">
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">Olá senhor(a) coordenador(a)</p>
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">Notificação de cadastro de ocorrências</p>
                         <table border="0" cellpadding="0" cellspacing="0" class="btn btn-primary" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; box-sizing: border-box;">


### PR DESCRIPTION
Improves accessibility score adding alt text to IFMS logo.

![image](https://user-images.githubusercontent.com/2979365/198424131-b7a34de5-9737-43db-a861-ec14b84dc804.png)
